### PR TITLE
Add basic outline of what burndown chart page should look like

### DIFF
--- a/manager/templates/manager/burndown.html
+++ b/manager/templates/manager/burndown.html
@@ -1,4 +1,43 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
+{% block headcontent %}
+<title>Taskboard {{taskboard_id}} Burndown Chart</title>
+{% endblock %}
 {% block content %}
-Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolorem sapiente alias vitae. Nesciunt quo autem maxime, magni quis sunt laborum cupiditate consequatur unde numquam consequuntur enim exercitationem tenetur non earum!
+
+<div class="container-fluid">
+  <a href="{% url 'manager:taskboard' taskboard_id %}" class="btn btn-secondary my-3">
+    Back to Taskboard
+  </a>
+  <div class="row align-items-start">
+    <div class="col">
+      Graph {{taskboard_id}}
+    </div>
+
+    <div class="col">
+      <h2>Select Event</h2>
+      <form method="post" action="#">
+        {% csrf_token %}
+
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault">
+          <label class="form-check-label" for="flexCheckDefault">
+            Default checkbox
+          </label>
+        </div>
+
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" value="" id="flexCheckChecked" checked>
+          <label class="form-check-label" for="flexCheckChecked">
+            Checked checkbox
+          </label>
+        </div>
+
+        <input type="submit" value="View event on graph">
+
+      </form>
+    
+  </div>
+
+</div>
+
 {% endblock %}

--- a/manager/templates/manager/burndown.html
+++ b/manager/templates/manager/burndown.html
@@ -11,22 +11,26 @@
   <div class="row align-items-start">
     <div class="col">
       Graph {{taskboard_id}}
+
+      {% for event in events %}
+      {{event}}
+      {% endfor %}
     </div>
 
     <div class="col">
       <h2>Select Event</h2>
-      <form method="post" action="#">
+      <form method="post">
         {% csrf_token %}
 
         <div class="form-check">
-          <input class="form-check-input" type="checkbox" value="" id="flexCheckDefault">
+          <input class="form-check-input" name="events" type="checkbox" value="a" id="flexCheckDefault">
           <label class="form-check-label" for="flexCheckDefault">
             Default checkbox
           </label>
         </div>
 
         <div class="form-check">
-          <input class="form-check-input" type="checkbox" value="" id="flexCheckChecked" checked>
+          <input class="form-check-input" name="events" type="checkbox" value="c" id="flexCheckChecked">
           <label class="form-check-label" for="flexCheckChecked">
             Checked checkbox
           </label>

--- a/manager/tests/test_burndown_chart_views.py
+++ b/manager/tests/test_burndown_chart_views.py
@@ -1,0 +1,38 @@
+"""Test Burndown chart views."""
+
+from django.test import TestCase
+from django.urls import reverse
+
+from manager.models import Taskboard
+
+
+def create_taskboard(name: str = "Today") -> Taskboard:
+    """
+    Create a taskboard with the given name.
+
+    :returns: A Taskboard object with the given name.
+    """
+    return Taskboard.objects.create(name=name)
+
+
+class TestBurndownChartView(TestCase):
+    """Test the burndown chat view."""
+
+    def test_get_request(self):
+        """Test sending get request."""
+        tb = create_taskboard()
+        url = reverse("manager:burndown_chart", args=(tb.id,))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_post_request(self):
+        """Test sending post request.
+
+        The BurndownChartView should get the events data.
+        """
+        tb = create_taskboard()
+        url = reverse("manager:burndown_chart", args=(tb.id,))
+        data = {"events": ["a", "b", "v"]}
+        response = self.client.post(url, data)
+        self.assertEqual(response.context["events"], data["events"])
+        self.assertEqual(response.status_code, 200)

--- a/manager/urls.py
+++ b/manager/urls.py
@@ -17,6 +17,5 @@ urlpatterns = [
     path("event/create/", views.create_event, name="create_event"),
     path("event/<int:event_id>/delete/", views.delete_event, name="delete_event"),
     path("event/<int:event_id>/update/", views.update_event, name="update_event"),
-    # TODO replace views.TaskboardView.as_view() with the view for burndown chart
-    path("taskboard/<int:taskboard_id>/burndown/", views.display_burndown_chart, name="burndown_chart"),
+    path("taskboard/<int:taskboard_id>/burndown/", views.BurndownView.as_view(), name="burndown_chart"),
 ]

--- a/manager/views.py
+++ b/manager/views.py
@@ -278,4 +278,5 @@ def display_burndown_chart(request, taskboard_id) -> HttpResponse:
     :param request: Django's request object.
     :return: Renders the burndown chart page.
     """
-    return render(request, "manager/burndown.html", {})
+    context = {"taskboard_id": taskboard_id}
+    return render(request, "manager/burndown.html", context)

--- a/manager/views.py
+++ b/manager/views.py
@@ -286,12 +286,12 @@ class BurndownView(generic.View):
         return context
 
     def get(self, request, *args, **kwargs):
-        """Render burndown chart page when there's get request."""
+        """Render burndown chart page when there's a GET request."""
         context = self.get_context_data(**kwargs)
-        return render(request, "manager/burndown.html", context)
+        return render(request, self.template_name, context)
 
     def post(self, request, *args, **kwargs):
-        """Render burndown chart page when there's get request."""
+        """Render burndown chart page when there's a POST request."""
         kwargs["events"] = request.POST.getlist("events")
         context = self.get_context_data(**kwargs)
-        return render(request, "manager/burndown.html", context)
+        return render(request, self.template_name, context)

--- a/manager/views.py
+++ b/manager/views.py
@@ -272,11 +272,26 @@ def update_taskboard(request, taskboard_id: int) -> HttpResponse:
     return redirect(reverse("manager:taskboard_index"))
 
 
-def display_burndown_chart(request, taskboard_id) -> HttpResponse:
-    """Display the burndown chart page.
+class BurndownView(generic.View):
+    """A view for the burndown chart page."""
 
-    :param request: Django's request object.
-    :return: Renders the burndown chart page.
-    """
-    context = {"taskboard_id": taskboard_id}
-    return render(request, "manager/burndown.html", context)
+    template_name = "manager/burndown.html"
+
+    def get_context_data(self, **kwargs):
+        """Get context data for burndown chart view."""
+        context = {}
+        context["taskboard_id"] = self.kwargs.get("taskboard_id")
+        if "events" in kwargs:
+            context["events"] = kwargs["events"]
+        return context
+
+    def get(self, request, *args, **kwargs):
+        """Render burndown chart page when there's get request."""
+        context = self.get_context_data(**kwargs)
+        return render(request, "manager/burndown.html", context)
+
+    def post(self, request, *args, **kwargs):
+        """Render burndown chart page when there's get request."""
+        kwargs["events"] = request.POST.getlist("events")
+        context = self.get_context_data(**kwargs)
+        return render(request, "manager/burndown.html", context)


### PR DESCRIPTION
- Add a basic HTML file for the burndown chart page
- Modify display_burndown_chart to a class-based view that can handle both get and post request
- The events are just dummy events for now
- Most of the work probably needs to be replaced once we switch to REST API anyway but I want to merge first to at least save the progress before refractoring.