### PR TITLE
fix incorrect indentation in patch config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,10 +4,10 @@ coverage:
       default:
         target: 80% # at LEAST 80% of your code should be thoroughly tested
         threshold: 1% # you get 1% difference leniency
-      patch: # same as project but for checking in pull requests
-        default:
-          target: 80%
-          threshold: 1%
+    patch: # same as project but for checking in pull requests
+      default:
+        target: 80%
+        threshold: 1%
 
 codecov:
   require_ci_to_pass: true


### PR DESCRIPTION
As in title, currently codecov is configured to require at least an improvement to coverage on push, which is not intended. I fixed the indent and now it should only require 80% coverage as intended.