### PR TITLE
Make calendar use REST API

### DIFF
--- a/manager/serializers/event_serializer.py
+++ b/manager/serializers/event_serializer.py
@@ -7,8 +7,16 @@ from manager.models import Event
 class EventSerializer(serializers.ModelSerializer):
     """Serializer for the Event model."""
 
+    type = serializers.SerializerMethodField()
+    start = serializers.DateTimeField(source="start_date")
+    end = serializers.DateTimeField(source="end_date")
+
     class Meta:
         """Meta definition for Event."""
 
         model = Event
         fields = "__all__"
+
+    def get_type(self, obj):
+        """Get the value of a custom field to indicate that this is an event."""
+        return "event"

--- a/manager/serializers/task_serializer.py
+++ b/manager/serializers/task_serializer.py
@@ -7,8 +7,15 @@ from manager.models import Task
 class TaskSerializer(serializers.ModelSerializer):
     """Serializer for the Task model."""
 
+    type = serializers.SerializerMethodField()
+    start = serializers.DateTimeField(source="end_date")
+
     class Meta:
         """Meta definition for Task."""
 
         model = Task
         fields = "__all__"
+
+    def get_type(self, obj):
+        """Get the value of a custom field to indicate that this is a task."""
+        return "task"

--- a/manager/static/manager/calendar.css
+++ b/manager/static/manager/calendar.css
@@ -2,3 +2,7 @@
   max-width: 90vw;
   margin: 10px auto;
 }
+
+textarea {
+  resize: none;
+}

--- a/manager/static/manager/calendar.css
+++ b/manager/static/manager/calendar.css
@@ -6,3 +6,7 @@
 textarea {
   resize: none;
 }
+
+.hidden {
+  display: none;
+}

--- a/manager/static/manager/calendar.js
+++ b/manager/static/manager/calendar.js
@@ -28,7 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
         lazyFetching: true,
       },
       {
-        url: '/api/tasks/',
+        url: '/api/tasks/?exclude=DONE',
         color: '#FF00FF',
         lazyFetching: true,
       }

--- a/manager/static/manager/calendar.js
+++ b/manager/static/manager/calendar.js
@@ -1,5 +1,3 @@
-const allEvents = JSON.parse(document.getElementById('events-data').textContent);
-const allTasks = JSON.parse(document.getElementById('tasks-data').textContent);
 const eventDetailsModal = new bootstrap.Modal(document.getElementById('eventDetailsModal'), {
   focus: true
 });
@@ -22,7 +20,19 @@ document.addEventListener('DOMContentLoaded', () => {
     selectable: true,
     dayMaxEvents: true,
     timeZone: 'UTC',
-    events: allEvents.concat(allTasks),
+    eventSources: [
+      {
+        url: '/api/events/',
+        color: '#6767fe',
+        editable: true,
+        lazyFetching: true,
+      },
+      {
+        url: '/api/tasks/',
+        color: '#FF00FF',
+        lazyFetching: true,
+      }
+    ],
     eventClick: (eventClickInfo) => {
       var eventObj = eventClickInfo.event;
       var popover = document.querySelector('.fc-popover');

--- a/manager/templates/manager/calendar.html
+++ b/manager/templates/manager/calendar.html
@@ -21,15 +21,15 @@
             <label for="eventStart" class="form-label fw-bold"> Start :</label>
             <input type="datetime-local" readonly class="form-control-plaintext" id="eventStart">
           </div>
-  
+
           <div class="mb-3">
             <label for="eventEnd" class="form-label fw-bold"> End :</label>
             <input type="datetime-local" readonly class="form-control-plaintext" id="eventEnd">
           </div>
-  
+
           <div class="mb-3">
             <label for="eventDetails" class="form-label fw-bold">Details :</label>
-            <input type="text" readonly class="form-control-plaintext" id="eventDetails">
+            <textarea readonly class="form-control-plaintext" id="eventDetails" rows="4"></textarea>
           </div>
 
         </div>
@@ -53,11 +53,48 @@
             <label for="taskDue" class="form-label fw-bold"> Due :</label>
             <input type="datetime-local" readonly class="form-control-plaintext" id="taskDue">
           </div>
-  
+
           <div class="mb-3">
             <label for="taskDetails" class="form-label fw-bold">Details :</label>
-            <input type="text" readonly class="form-control-plaintext" id="taskDetails">
+            <textarea readonly class="form-control-plaintext" id="taskDetails" rows="4"></textarea>
           </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="addEventModal" tabindex="-1">
+  <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title fs-5">Add a new event</h1>
+        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+            <label for="newTitle" class="form-label fw-bold"> Title :</label>
+            <input type="text" class="form-control" id="newTitle">
+          </div>
+
+          <div class="mb-3">
+            <label for="newStart" class="form-label fw-bold"> Start :</label>
+            <input type="datetime-local" class="form-control" id="newStart">
+          </div>
+
+          <div class="mb-3">
+            <label for="newEnd" class="form-label fw-bold"> End :</label>
+            <input type="datetime-local" class="form-control" id="newEnd">
+          </div>
+
+          <div class="mb-3">
+            <label for="newDetails" class="form-label fw-bold">Details :</label>
+            <textarea class="form-control" id="newDetails" placeholder="optional" rows="4"></textarea>
+          </div>
+
+        </div>
+        <div class="modal-footer">
+          <button class="btn btn-sm btn-primary" id="addButton">Add</a>
+        </div>
       </div>
     </div>
   </div>

--- a/manager/templates/manager/calendar.html
+++ b/manager/templates/manager/calendar.html
@@ -17,6 +17,11 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
       </div>
         <div class="modal-body">
+          <div class="mb-3 hidden">
+            <label for="eventTitle" class="form-label fw-bold"> New title :</label>
+            <input type="text" class="form-control" id="eventTitle">
+          </div>
+
           <div class="mb-3">
             <label for="eventStart" class="form-label fw-bold"> Start :</label>
             <input type="datetime-local" readonly class="form-control-plaintext" id="eventStart">
@@ -36,6 +41,8 @@
         <div class="modal-footer">
           <button class="btn btn-sm btn-primary" id="editButton">Edit</a>
           <button class="btn btn-sm btn-danger" id="deleteButton">Delete</a>
+          <button class="btn btn-sm btn-primary hidden" id="doneButton">Done</a>
+          <button class="btn btn-sm btn-danger hidden" id="cancelButton">Cancel</a>
         </div>
     </div>
   </div>

--- a/manager/templates/manager/calendar.html
+++ b/manager/templates/manager/calendar.html
@@ -62,6 +62,4 @@
     </div>
   </div>
 </div>
-{{ events|json_script:"events-data" }}
-{{ tasks|json_script:"tasks-data" }}
 {% endblock %}

--- a/manager/tests/test_events.py
+++ b/manager/tests/test_events.py
@@ -53,13 +53,11 @@ def create_event_json(
     if id is not None:
         data["id"] = str(id)
 
-    data.update({"title": title, "start_date": start_date, "end_date": end_date})
+    data.update({"title": title, "start": start_date, "end": end_date})
 
     return data
 
 
-# to the group who's working on the taskboard could you please
-# refactor this to your test suit. While we're here shall we also do codecov?
 class EventViewSetTests(TestCase):
     """Tests for the Event API viewset."""
 
@@ -152,10 +150,10 @@ class EventViewSetTests(TestCase):
         request = self.client.get(f"/api/events/{event.id}/")
         self.assertEqual(request.data["title"], event_json["title"])
         self.assertEqual(
-            datetime.fromisoformat(request.data["start_date"]), event_json["start_date"]
+            datetime.fromisoformat(request.data["start_date"]), event_json["start"]
         )
         self.assertEqual(
-            datetime.fromisoformat(request.data["end_date"]), event_json["end_date"]
+            datetime.fromisoformat(request.data["end_date"]), event_json["end"]
         )
         self.assertEqual(request.data["details"], event_json["details"])
 

--- a/manager/tests/test_task_views.py
+++ b/manager/tests/test_task_views.py
@@ -62,12 +62,31 @@ class TaskViewTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 3)
 
-    def test_get_one_tasks(self):
+    def test_get_one_task(self):
         """Test getting a specific task info."""
         response = self.client.get(f"/api/tasks/{self.task_2.id}/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["title"], self.task_2.title)
         self.assertEqual(response.data["status"], self.task_2.status)
+
+    def test_get_all_status_not_done(self):
+        """Test getting tasks with status not equal to DONE."""
+        create_task("Done Task", "DONE", self.taskboard_1)
+        response = self.client.get("/api/tasks/?exclude=DONE")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 3)
+
+    def test_get_all_status_not_in_progress(self):
+        """Test getting tasks with status not equal to INPROGRESS."""
+        response = self.client.get("/api/tasks/?exclude=INPROGRESS")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    def test_get_all_status_not_todo(self):
+        """Test getting tasks with status not equal to TODO."""
+        response = self.client.get("/api/tasks/?exclude=TODO")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
 
     def test_create_valid_task(self):
         """Test creating a Task."""

--- a/manager/tests/test_task_views.py
+++ b/manager/tests/test_task_views.py
@@ -36,7 +36,7 @@ def create_task_json(
         {
             "title": title,
             "status": task_status.upper(),
-            "end_date": end_date,
+            "start": end_date,
             "taskboard": taskboard.id,
         }
     )

--- a/manager/views/calendar.py
+++ b/manager/views/calendar.py
@@ -1,47 +1,9 @@
 """A class-based view for the calendar page."""
 
 from django.views import generic
-from typing import Any
-from django.urls import reverse
-from manager.models import Event, Task
 
 
 class CalendarView(generic.TemplateView):
     """A view that display the calendar that show events and tasks."""
 
     template_name = "manager/calendar.html"
-
-    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        """Create context dictionary used to render the template.
-
-        :return: A dictionary containing a list of dicts about events
-                 information to be converted into array.
-        """
-        all_events = Event.objects.all()
-        all_tasks = Task.objects.all()
-        events_list = []
-        tasks_list = []
-        for event in all_events:
-            event_info = {
-                "type": "event",
-                "title": event.title,
-                "start": event.start_date.isoformat(),
-                "end": event.end_date.isoformat(),
-                "color": "#6767fe",
-                "editable": True,
-                "details": event.details,
-                "update": reverse("manager:update_event", args=(event.id,)),
-            }
-            events_list.append(event_info)
-        for task in all_tasks:
-            tasks_info = {
-                "type": "task",
-                "title": task.title,
-                "start": task.end_date.isoformat(),
-                "color": "#FF00FF",
-                "editable": False,
-                "details": task.details,
-            }
-            tasks_list.append(tasks_info)
-        context = {"events": events_list, "tasks": tasks_list}
-        return context

--- a/manager/views/tasks.py
+++ b/manager/views/tasks.py
@@ -19,7 +19,7 @@ class TaskViewSet(viewsets.ViewSet):
         :return: Response with tasks.
         """
         queryset = Task.objects.all()
-        ignore_status = request.query_params.get('exclude')
+        ignore_status = request.query_params.get("exclude")
         if ignore_status:
             queryset = Task.objects.filter(~Q(status=ignore_status))
         serializer = TaskSerializer(queryset, many=True)

--- a/manager/views/tasks.py
+++ b/manager/views/tasks.py
@@ -1,6 +1,7 @@
 """Views for handling task creation, deletion and updates."""
 
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import Q
 from manager.models import Task
 from rest_framework import status, viewsets
 from rest_framework.response import Response
@@ -18,6 +19,9 @@ class TaskViewSet(viewsets.ViewSet):
         :return: Response with tasks.
         """
         queryset = Task.objects.all()
+        ignore_status = request.query_params.get('exclude')
+        if ignore_status:
+            queryset = Task.objects.filter(~Q(status=ignore_status))
         serializer = TaskSerializer(queryset, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
The calendar now gets or submits data using REST API. The leftover features are all implemented. Creating an event can be done via the `Add Event`. DateTime can also be selected by selecting a day on the month view, selecting multiple days on the month view, or selecting a time frame on any other view except the list view. Updating and deleting events can be done using the event details model. Also please make sure that your Django timezone setting is set to UTC, because the calendar will change the date received to match your local browser timezone.