### PR TITLE
Fix time estimate update bug

### DIFF
--- a/manager/models/task.py
+++ b/manager/models/task.py
@@ -28,13 +28,42 @@ class Task(models.Model):
     )
     time_estimate = models.IntegerField(default=0)
 
-    def __compute_time_diff(self, new_time: int) -> int:
+    def __compute_time_diff(self) -> int:
         """Compute the difference between old and new time estimate."""
         try:
             old_time = Task.objects.get(pk=self.pk).time_estimate
-            return new_time - old_time
+            return self.time_estimate - old_time
         except Task.DoesNotExist:
-            return new_time
+            return self.time_estimate
+
+    def __status_changed_to_done(self) -> bool:
+        """Check whether status of tasks are changed to DONE.
+
+        :return: True if the task's status changed from something else to DONE.
+        Or the task is created with status=DONE.
+        Otherwise, return false.
+        """
+        try:
+            old_status = Task.objects.get(pk=self.pk).status
+            if self.status == old_status:
+                return False
+            return self.status == "DONE"
+        except Task.DoesNotExist:
+            return self.status == "DONE"
+
+    def __status_changed_from_done(self) -> bool:
+        """Check whether status of tasks are changed from DONE.
+
+        :return: True if the task's status changed from DONE to something else.
+        Otherwise, return false.
+        """
+        try:
+            old_status = Task.objects.get(pk=self.pk).status
+            if self.status == old_status:
+                return False
+            return old_status == "DONE"
+        except Task.DoesNotExist:
+            return False
 
     def save(self, *args, **kwargs):
         """Override default save method.
@@ -48,7 +77,11 @@ class Task(models.Model):
         eh = EstimateHistory.objects.get(
             date=timezone.localdate(), taskboard=self.taskboard
         )
-        eh.time_remaining += self.__compute_time_diff(self.time_estimate)
+        eh.time_remaining += self.__compute_time_diff()
+        if self.__status_changed_to_done():
+            eh.time_remaining -= self.time_estimate
+        elif self.__status_changed_from_done():
+            eh.time_remaining += self.time_estimate
         eh.save()
 
         super().save(*args, **kwargs)
@@ -58,11 +91,10 @@ class Task(models.Model):
 
         Also subtracts the time remaining in the related EstimateHistory object.
         """
-        est = self.time_estimate
         eh = EstimateHistory.objects.get(
             date=timezone.localdate(), taskboard=self.taskboard
         )
-        eh.time_remaining -= est
+        eh.time_remaining -= self.time_estimate
         eh.save()
 
         super().delete(using, keep_parents)

--- a/manager/tests/test_estimate_history.py
+++ b/manager/tests/test_estimate_history.py
@@ -12,9 +12,9 @@ class EstimateHistoryTest(BaseTestCase):
     def test_adding_same_day_tasks(self):
         """Test adding multiple tasks within the same day."""
         tb = create_taskboard(self.user1, "test")
-        Task.objects.create(title="someting", taskboard=tb, time_estimate=3)
-        Task.objects.create(title="someting3", taskboard=tb, time_estimate=5)
-        Task.objects.create(title="someting2", taskboard=tb, time_estimate=7)
+        Task.objects.create(title="something", taskboard=tb, time_estimate=3)
+        Task.objects.create(title="something3", taskboard=tb, time_estimate=5)
+        Task.objects.create(title="something2", taskboard=tb, time_estimate=7)
         self.assertEqual(EstimateHistory.objects.count(), 1)
         eh = EstimateHistory.objects.first()
         self.assertEqual(eh.time_remaining, 3 + 5 + 7)
@@ -22,7 +22,7 @@ class EstimateHistoryTest(BaseTestCase):
     def test_changing_time_estimate(self):
         """Test changing time estimate of a task."""
         tb = create_taskboard(self.user1, "test")
-        t = Task.objects.create(title="someting2", taskboard=tb, time_estimate=7)
+        t = Task.objects.create(title="something2", taskboard=tb, time_estimate=7)
         t.time_estimate = 6
         t.save()
         eh = EstimateHistory.objects.first()
@@ -53,9 +53,49 @@ class EstimateHistoryTest(BaseTestCase):
     def test_deleting_task_also_subtract_estimate_time(self):
         """If a task got deleted, the time estimate should go down as well."""
         tb = create_taskboard(self.user1, "test")
-        t = Task.objects.create(title="someting2", taskboard=tb, time_estimate=7)
+        t = Task.objects.create(title="something2", taskboard=tb, time_estimate=7)
         eh = EstimateHistory.objects.first()
         self.assertEqual(eh.time_remaining, 7)
         t.delete()
         eh.refresh_from_db()
+        self.assertEqual(eh.time_remaining, 0)
+
+    def test_changing_status(self):
+        """Test changing between different task status.
+
+        Changing task status to DONE should subtracts the task's time remaining
+        from the time estimate. Changing it back to DONE should add it back up.
+        """
+        tb = create_taskboard(self.user1, "test")
+        t = Task.objects.create(title="something1", taskboard=tb, time_estimate=7)
+        t2 = Task.objects.create(title="something2", taskboard=tb, time_estimate=3)
+        t.save()
+        t2.save()
+        eh = EstimateHistory.objects.first()
+        self.assertEqual(eh.time_remaining, 7 + 3)
+        for _ in range(2):
+            t.status = "DONE"
+            t.save()
+            eh.refresh_from_db()
+            self.assertEqual(eh.time_remaining, 0 + 3)
+        t.status = "IN PROGRESS"
+        t.save()
+        eh.refresh_from_db()
+        self.assertEqual(eh.time_remaining, 7 + 3)
+        t.status = "TODO"
+        t.save()
+        eh.refresh_from_db()
+        self.assertEqual(eh.time_remaining, 7 + 3)
+
+    def test_creating_task_with_status_done(self):
+        """Create a task where the status is set to DONE.
+
+        It should not add the time estimate.
+        """
+        tb = create_taskboard(self.user1)
+        t2 = Task.objects.create(
+            title="something2", taskboard=tb, time_estimate=3, status="DONE"
+        )
+        t2.save()
+        eh = EstimateHistory.objects.first()
         self.assertEqual(eh.time_remaining, 0)

--- a/manager/tests/test_estimate_history.py
+++ b/manager/tests/test_estimate_history.py
@@ -93,9 +93,24 @@ class EstimateHistoryTest(BaseTestCase):
         It should not add the time estimate.
         """
         tb = create_taskboard(self.user1)
-        t2 = Task.objects.create(
+        t = Task.objects.create(
             title="something2", taskboard=tb, time_estimate=3, status="DONE"
         )
-        t2.save()
+        t.save()
+        eh = EstimateHistory.objects.first()
+        self.assertEqual(eh.time_remaining, 0)
+
+    def test_changing_time_estimate_of_done_tasks(self):
+        """Test changing time estimate of tasks that are marked as done.
+
+        It should not affect time estimate of an estimate history object.
+        """
+        tb = create_taskboard(self.user1)
+        t = Task.objects.create(
+            title="something2", taskboard=tb, time_estimate=3000, status="DONE"
+        )
+        t.save()
+        t.time_estimate = 7
+        t.save()
         eh = EstimateHistory.objects.first()
         self.assertEqual(eh.time_remaining, 0)


### PR DESCRIPTION
- Fix bugs where the time estimate doesn't change when the user changes task status to and from "Done".
- I'd like @ErikLupical to review these changes since they will directly affect the burndown chart he's working on.