### PR TITLE
Fix issues related to task/taskboard API

### DIFF
--- a/manager/tests/test_task_views.py
+++ b/manager/tests/test_task_views.py
@@ -111,18 +111,6 @@ class TaskViewTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
 
-    def test_get_user_tasks(self):
-        """Test getting all tasks belonging to a specific user."""
-        user2 = User.objects.create_user(
-            username="Howard.W", email="testuser@nowhere.com"
-        )
-        user2.save()
-        tb3 = create_taskboard(user2, "Daily board")
-        create_task("Go shopping", "TODO", tb3)
-        response = self.client.get(f"/api/tasks/?user={self.user1.id}")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data), 3)
-
     def test_get_tasks_in_one_taskboard_exclude_status(self):
         """Test getting tasks except those with the given status in a taskboard."""
         response = self.client.get(f"/api/tasks/?taskboard={self.taskboard_1.id}")

--- a/manager/tests/test_validation.py
+++ b/manager/tests/test_validation.py
@@ -4,8 +4,6 @@ from datetime import datetime
 from rest_framework import status
 from django.utils import timezone
 from django.test import TestCase
-from manager.models import Taskboard, Task, StudentInfo
-from typing import Any, Optional
 from .templates_for_tests import create_taskboard, create_task
 from django.contrib.auth.models import User, Permission
 
@@ -46,10 +44,7 @@ class TaskViewTests(TestCase):
         self.user3.save()
 
     def test_get_other_users_tasks(self):
-        """
-        Only the parent of a user or the user themselves
-        should be able to view a user's tasks.
-        """
+        """Only the parent of a user or the user can view the user's tasks."""
         tb = create_taskboard(self.user2, "Shopping list")
         create_task("Buy milk", "TODO", tb)
         create_task("Buy cool toy", "INPROGRESS", tb)
@@ -63,10 +58,7 @@ class TaskViewTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_get_other_users_taskboard(self):
-        """
-        Only the parent of a user or the user themselves
-        should be able to view a user's task boards.
-        """
+        """Only the parent of a user or the user can view the user's taskboards."""
         tb = create_taskboard(self.user2, "Shopping list")
         create_task("Buy milk", "TODO", tb)
         self.user1.user_permissions.add(Permission.objects.get(codename="is_parent"))

--- a/manager/tests/test_validation.py
+++ b/manager/tests/test_validation.py
@@ -53,9 +53,7 @@ class TaskViewTests(TestCase):
         tb = create_taskboard(self.user2, "Shopping list")
         create_task("Buy milk", "TODO", tb)
         create_task("Buy cool toy", "INPROGRESS", tb)
-        self.user1.user_permissions.add(
-            Permission.objects.get(codename="is_parent")
-        )
+        self.user1.user_permissions.add(Permission.objects.get(codename="is_parent"))
         self.assertTrue(self.user1.has_perm("manager.is_parent"))
         response = self.client.get(f"/api/tasks/?user={self.user2.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -71,9 +69,7 @@ class TaskViewTests(TestCase):
         """
         tb = create_taskboard(self.user2, "Shopping list")
         create_task("Buy milk", "TODO", tb)
-        self.user1.user_permissions.add(
-            Permission.objects.get(codename="is_parent")
-        )
+        self.user1.user_permissions.add(Permission.objects.get(codename="is_parent"))
         self.assertTrue(self.user1.has_perm("manager.is_parent"))
         response = self.client.get(f"/api/tasks/?taskboard={tb.id}")
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/manager/tests/test_validation.py
+++ b/manager/tests/test_validation.py
@@ -1,0 +1,83 @@
+"""Test user checking for CRUD operations."""
+
+from datetime import datetime
+from rest_framework import status
+from django.utils import timezone
+from django.test import TestCase
+from manager.models import Taskboard, Task, StudentInfo
+from typing import Any, Optional
+from .templates_for_tests import create_taskboard, create_task
+from django.contrib.auth.models import User, Permission
+
+
+class TaskViewTests(TestCase):
+    """Tests for TaskViewSet."""
+
+    def setUp(self):
+        """Create Taskboards with some tasks."""
+        super().setUp()
+        # add the base user
+        self.username = "Tester"
+        self.password = "Bestbytest!123"
+        self.user1 = User.objects.create_user(
+            username=self.username, email="testuser@nowhere.com"
+        )
+        self.user1.set_password(self.password)
+        self.user1.save()
+        self.client.login(username=self.username, password=self.password)
+        due_date = timezone.make_aware(datetime(2030, 10, 2, 10))
+        self.taskboard_1 = create_taskboard(self.user1, "Today")
+        self.taskboard_2 = create_taskboard(self.user1, "Today but number 2")
+        self.task_1 = create_task("Task 1", "TODO", self.taskboard_1, due_date)
+        self.task_2 = create_task("Task 2", "INPROGRESS", self.taskboard_1)
+        self.task_3 = create_task("Task 3", "TODO", self.taskboard_2, due_date)
+        # add the student
+        self.user2 = User.objects.create_user(
+            username="Conway", email="testuser2@nowhere.com"
+        )
+        self.user2.set_password("Sonata")
+        self.user2.save()
+        self.user2.studentinfo.parent.add(self.user1)
+        # A random bad guy who wants to leak data
+        self.user3 = User.objects.create_user(
+            username="JohnBadguy", email="Hacker@anywhere.com"
+        )
+        self.user3.set_password("l33tcrew420")
+        self.user3.save()
+
+    def test_get_other_users_tasks(self):
+        """
+        Only the parent of a user or the user themselves
+        should be able to view a user's tasks.
+        """
+        tb = create_taskboard(self.user2, "Shopping list")
+        create_task("Buy milk", "TODO", tb)
+        create_task("Buy cool toy", "INPROGRESS", tb)
+        self.user1.user_permissions.add(
+            Permission.objects.get(codename="is_parent")
+        )
+        self.assertTrue(self.user1.has_perm("manager.is_parent"))
+        response = self.client.get(f"/api/tasks/?user={self.user2.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        self.client.login(username="JohnBadguy", password="l33tcrew420")
+        response = self.client.get(f"/api/tasks/?user={self.user2.id}")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_other_users_taskboard(self):
+        """
+        Only the parent of a user or the user themselves
+        should be able to view a user's task boards.
+        """
+        tb = create_taskboard(self.user2, "Shopping list")
+        create_task("Buy milk", "TODO", tb)
+        self.user1.user_permissions.add(
+            Permission.objects.get(codename="is_parent")
+        )
+        self.assertTrue(self.user1.has_perm("manager.is_parent"))
+        response = self.client.get(f"/api/tasks/?taskboard={tb.id}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.client.login(username="JohnBadguy", password="l33tcrew420")
+        response = self.client.get(f"/api/tasks/?taskboard={tb.id}")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/manager/views/taskboard.py
+++ b/manager/views/taskboard.py
@@ -1,9 +1,10 @@
 """Views for handling taskboard creation, deletion, update and render."""
 
 from rest_framework.authtoken.admin import User
+from rest_framework.response import Response
 from manager.models import Taskboard
 from django.views import generic
-from rest_framework import viewsets
+from rest_framework import viewsets, status
 from manager.serializers import TaskboardSerializer
 from django.shortcuts import redirect, reverse, render
 
@@ -26,6 +27,20 @@ class TaskboardViewSet(viewsets.ModelViewSet):
         if query:
             return Taskboard.objects.filter(user__pk=query)
         return Taskboard.objects.filter(user=self.request.user)
+
+    def create(self, request):
+        """
+        Create a new Task object.
+
+        :param request: The HTTP request with event data.
+        :return: Response with created event.
+        """
+        data = request.data
+        serializer = TaskboardSerializer(data=data)
+        if serializer.is_valid():
+            serializer.save(user=self.request.user)
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 class TaskboardIndexView(generic.TemplateView):

--- a/manager/views/tasks.py
+++ b/manager/views/tasks.py
@@ -65,6 +65,7 @@ class TaskViewSet(viewsets.ViewSet):
         # get all tasks belonging to the current user
         else:
             queryset = Task.objects.filter(taskboard__user=request.user)
+        queryset = queryset.order_by("end_date")
         serializer = TaskSerializer(queryset, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 

--- a/manager/views/tasks.py
+++ b/manager/views/tasks.py
@@ -1,11 +1,20 @@
 """Views for handling task creation, deletion and updates."""
 
+from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
-from manager.models import Task
+from manager.models import Task, StudentInfo, Taskboard
 from rest_framework import status, viewsets
 from rest_framework.response import Response
 from manager.serializers import TaskSerializer
+
+
+def is_user_authorized(requesting_user: User, user_id:int) -> bool:
+    """Check if the current user has access to another user's content."""
+    if not requesting_user.has_perm("manager.is_parent"):
+        return False
+    info = StudentInfo.objects.get(user=user_id)
+    return info.parent.filter(email=requesting_user.email).exists()
 
 
 class TaskViewSet(viewsets.ViewSet):
@@ -25,7 +34,6 @@ class TaskViewSet(viewsets.ViewSet):
         :param request: The HTTP request.
         :return: Response with tasks.
         """
-        queryset = Task.objects.all()
         taskboard_id = request.query_params.get("taskboard")
         ignore_status = request.query_params.get("exclude")
         user = request.query_params.get("user")
@@ -36,15 +44,27 @@ class TaskViewSet(viewsets.ViewSet):
             )
         # get tasks in a taskboard.
         elif taskboard_id:
+            # see if the taskboard exists
+            try:
+                owner = Taskboard.objects.get(pk=taskboard_id).user.id
+            except Taskboard.DoesNotExist:
+                return Response(status=status.HTTP_404_NOT_FOUND)
+            if request.user.id != owner and not is_user_authorized(request.user, owner):
+                return Response(status=status.HTTP_404_NOT_FOUND)
             queryset = Task.objects.filter(taskboard=taskboard_id)
         # get non-finished tasks for the calendar.
         elif ignore_status:
             queryset = Task.objects.filter(
                 ~Q(status=ignore_status), taskboard__user=request.user
             )
-        # get all tasks of the given user
+        # get all tasks of the given user, if self should have access
         elif user:
+            if not is_user_authorized(request.user, user):
+                return Response(status=status.HTTP_404_NOT_FOUND)
             queryset = Task.objects.filter(taskboard__user=user)
+        # get all tasks belonging to the current user
+        else:
+            queryset = Task.objects.filter(taskboard__user=request.user)
         serializer = TaskSerializer(queryset, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 

--- a/manager/views/tasks.py
+++ b/manager/views/tasks.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from manager.serializers import TaskSerializer
 
 
-def is_user_authorized(requesting_user: User, user_id:int) -> bool:
+def is_user_authorized(requesting_user: User, user_id: int) -> bool:
     """Check if the current user has access to another user's content."""
     if not requesting_user.has_perm("manager.is_parent"):
         return False


### PR DESCRIPTION
Issues fixed in this PR
- [x] #170 
- [x] #171 
- [x] #176 

What has been changed?
- Removed unnecessary getting query set in TaskViewSet:list
- TaskViewSet:list now only returns tasks that belong to the current user
- TaskboardViewSet:create always binds the current user to the Taskboard object created